### PR TITLE
Add runnable scripts for generation and training

### DIFF
--- a/gen_image.py
+++ b/gen_image.py
@@ -1,0 +1,55 @@
+"""Generate a handful of sample images using pretrained Stable Diffusion weights."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import torch
+from PIL import Image
+from transformers import CLIPTokenizer
+
+from model_define import load_pretrained_components
+
+BASE_DIR = Path(__file__).resolve().parent
+SD_DIR = BASE_DIR / "sd"
+if str(SD_DIR) not in sys.path:
+    sys.path.append(str(SD_DIR))
+
+from pipeline import generate  # type: ignore  # pylint: disable=wrong-import-position
+
+WEIGHTS_PATH = Path("/path/to/v1-5-pruned-emaonly.ckpt")
+TOKENIZER_NAME = "openai/clip-vit-large-patch14"
+OUTPUT_DIR = Path("generated_samples")
+
+PROMPTS = [
+    "Ultra detailed studio portrait of a jazz saxophonist, 85mm photograph, warm rim lighting",
+    "Impressionist oil painting of a rainy Paris boulevard at dusk, soft brush strokes",
+    "Golden hour landscape photograph of an alpine lake with snow-capped mountains and pine forests",
+    "Macro photograph of dewy succulent leaves, shallow depth of field, glistening bokeh",
+    "Vintage still life of a ceramic teapot with citrus fruit and velvet tablecloth, dramatic chiaroscuro",
+]
+
+
+def main() -> None:
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    models = load_pretrained_components(str(WEIGHTS_PATH), device)
+    tokenizer = CLIPTokenizer.from_pretrained(TOKENIZER_NAME)
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    for idx, prompt in enumerate(PROMPTS, start=1):
+        image_array = generate(
+            prompt=prompt,
+            uncond_prompt="",
+            models=models.as_dict(),
+            n_inference_steps=50,
+            seed=idx * 12345,
+            device=device,
+            tokenizer=tokenizer,
+        )
+        image = Image.fromarray(image_array)
+        image.save(OUTPUT_DIR / f"sample_{idx:02d}.png")
+        print(f"Saved sample_{idx:02d}.png for prompt: {prompt}")
+
+
+if __name__ == "__main__":
+    main()

--- a/model_define.py
+++ b/model_define.py
@@ -1,0 +1,116 @@
+"""High level model builders for the Stable Diffusion implementation.
+
+This module gathers the core neural networks defined under :mod:`sd`
+and exposes a beginner friendly API that keeps the class names close
+to the original paper:
+
+``CLIPTextEncoder``
+    Text encoder that turns token ids into contextual embeddings.
+``AutoencoderKL``
+    Variational autoencoder used to move between RGB pixels and the
+    latent space (4 channels at 64x64 when training 512x512 images).
+``UNetModel``
+    The denoising U-Net that predicts the noise component during the
+    diffusion process.
+
+The helpers below simply instantiate the PyTorch modules from this
+repository and optionally move them to the desired device.  Keeping the
+logic in a separate file makes it straightforward to reuse when writing
+training or inference scripts from scratch.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+from typing import Dict
+
+import torch
+
+# ``sd`` is a plain folder instead of a packaged module.  To be able to
+# ``import clip`` (and friends) we ensure that the directory sits on the
+# ``sys.path``.
+BASE_DIR = Path(__file__).resolve().parent
+SD_DIR = BASE_DIR / "sd"
+if str(SD_DIR) not in sys.path:
+    sys.path.append(str(SD_DIR))
+
+from clip import CLIP  # type: ignore  # pylint: disable=wrong-import-position
+from decoder import VAE_Decoder  # type: ignore  # pylint: disable=wrong-import-position
+from diffusion import Diffusion  # type: ignore  # pylint: disable=wrong-import-position
+from encoder import VAE_Encoder  # type: ignore  # pylint: disable=wrong-import-position
+import model_converter  # type: ignore  # pylint: disable=wrong-import-position
+
+
+@dataclass
+class StableDiffusionModels:
+    """Container that holds every neural network used in the pipeline."""
+
+    text_encoder: CLIP
+    vae_encoder: VAE_Encoder
+    vae_decoder: VAE_Decoder
+    unet: Diffusion
+
+    def to(self, device: torch.device | str) -> "StableDiffusionModels":
+        """Move all models to the provided device and return ``self``."""
+        self.text_encoder.to(device)
+        self.vae_encoder.to(device)
+        self.vae_decoder.to(device)
+        self.unet.to(device)
+        return self
+
+    def as_dict(self) -> Dict[str, torch.nn.Module]:
+        """Return the mapping expected by :func:`sd.pipeline.generate`."""
+        return {
+            "clip": self.text_encoder,
+            "encoder": self.vae_encoder,
+            "decoder": self.vae_decoder,
+            "diffusion": self.unet,
+        }
+
+
+def create_untrained_components(device: torch.device | str | None = None) -> StableDiffusionModels:
+    """Instantiate brand-new (randomly initialised) model components."""
+    models = StableDiffusionModels(
+        text_encoder=CLIP(),
+        vae_encoder=VAE_Encoder(),
+        vae_decoder=VAE_Decoder(),
+        unet=Diffusion(),
+    )
+    if device is not None:
+        models.to(device)
+    return models
+
+
+def load_pretrained_components(
+    ckpt_path: str,
+    device: torch.device | str = "cuda"
+) -> StableDiffusionModels:
+    """Load the official Stable Diffusion v1.x weights.
+
+    Parameters
+    ----------
+    ckpt_path:
+        Path to the original ``.ckpt`` file (the same format released by
+        CompVis / Stability AI).  The helper relies on
+        :mod:`sd.model_converter` to adapt the parameter names before
+        loading them into this repository's modules.
+    device:
+        Device that should hold the resulting models.  ``"cuda"`` is used
+        by default because the weights do not fit in CPU memory once the
+        training loop starts.
+    """
+    state_dict = model_converter.load_from_standard_weights(ckpt_path, device)
+    models = create_untrained_components(device)
+    models.text_encoder.load_state_dict(state_dict["clip"], strict=True)
+    models.vae_encoder.load_state_dict(state_dict["encoder"], strict=True)
+    models.vae_decoder.load_state_dict(state_dict["decoder"], strict=True)
+    models.unet.load_state_dict(state_dict["diffusion"], strict=True)
+    return models
+
+
+__all__ = [
+    "StableDiffusionModels",
+    "create_untrained_components",
+    "load_pretrained_components",
+]

--- a/train_model.py
+++ b/train_model.py
@@ -1,0 +1,249 @@
+"""Reusable text-to-image training utilities built on top of PyTorch."""
+from __future__ import annotations
+
+import csv
+import math
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+import numpy as np
+import torch
+from PIL import Image
+from torch import nn
+from torch.nn import functional as F
+from torch.optim import AdamW
+from torch.utils.data import DataLoader, Dataset
+from tqdm.auto import tqdm
+from transformers import CLIPTokenizer
+
+from model_define import (
+    StableDiffusionModels,
+    create_untrained_components,
+    load_pretrained_components,
+)
+
+# ``sd`` lives as a simple folder, therefore we add it to the module
+# search path before importing its utilities.
+SD_DIR = Path(__file__).resolve().parent / "sd"
+if str(SD_DIR) not in sys.path:
+    sys.path.append(str(SD_DIR))
+
+from ddpm import DDPMSampler  # type: ignore  # pylint: disable=wrong-import-position
+from pipeline import get_time_embedding  # type: ignore  # pylint: disable=wrong-import-position
+
+
+class ImageTextDataset(Dataset):
+    """Dataset that expects ``image_path`` and ``text`` columns in a CSV file."""
+
+    def __init__(self, metadata_path: str, images_root: str, resolution: int = 512):
+        super().__init__()
+        self.metadata_path = Path(metadata_path)
+        self.images_root = Path(images_root)
+        self.resolution = resolution
+        self.entries = self._load_metadata()
+
+    def _load_metadata(self) -> List[dict]:
+        rows: List[dict] = []
+        with self.metadata_path.open("r", newline="", encoding="utf-8") as handle:
+            reader = csv.DictReader(handle)
+            for row in reader:
+                image_path = row.get("image_path")
+                text = row.get("text")
+                if not image_path or not text:
+                    continue
+                rows.append({"image_path": image_path, "text": text})
+        if not rows:
+            raise ValueError(
+                f"No usable rows found in {self.metadata_path}. Expected 'image_path' and 'text' columns."
+            )
+        return rows
+
+    def __len__(self) -> int:  # pragma: no cover - trivial container
+        return len(self.entries)
+
+    def __getitem__(self, index: int):
+        entry = self.entries[index]
+        image_path = self.images_root / entry["image_path"]
+        with Image.open(image_path) as img:
+            img = img.convert("RGB")
+            img = img.resize((self.resolution, self.resolution), resample=Image.BICUBIC)
+            np_img = np.array(img).astype(np.float32) / 255.0
+        tensor = torch.from_numpy(np_img).permute(2, 0, 1)
+        tensor = tensor * 2.0 - 1.0  # Normalize to [-1, 1]
+        return {
+            "pixel_values": tensor,
+            "text": entry["text"],
+        }
+
+
+@dataclass
+class TrainConfig:
+    """Hyper-parameters shared by the pretraining and scratch scripts."""
+
+    output_dir: str
+    tokenizer_path: str
+    metadata_path: str
+    images_root: str
+    pretrained_ckpt: Optional[str] = None
+    device: str = "cuda"
+    resolution: int = 512
+    batch_size: int = 4
+    gradient_accumulation: int = 1
+    learning_rate: float = 1e-5
+    weight_decay: float = 1e-2
+    max_train_steps: int = 10_000
+    num_epochs: int = 1
+    num_workers: int = 4
+    mixed_precision: bool = True
+    save_every: int = 1_000
+    train_text_encoder: bool = False
+    train_vae: bool = False
+
+
+def _prepare_models(config: TrainConfig) -> StableDiffusionModels:
+    if config.pretrained_ckpt:
+        models = load_pretrained_components(config.pretrained_ckpt, config.device)
+    else:
+        models = create_untrained_components(config.device)
+    models.text_encoder.train(config.train_text_encoder)
+    models.vae_encoder.train(config.train_vae)
+    models.vae_decoder.train(config.train_vae)
+    models.unet.train(True)
+
+    if not config.train_text_encoder:
+        for param in models.text_encoder.parameters():
+            param.requires_grad_(False)
+    if not config.train_vae:
+        for param in models.vae_encoder.parameters():
+            param.requires_grad_(False)
+            param.grad = None
+        for param in models.vae_decoder.parameters():
+            param.requires_grad_(False)
+            param.grad = None
+    return models
+
+
+def _gather_trainable_parameters(models: StableDiffusionModels) -> Iterable[nn.Parameter]:
+    params: List[nn.Parameter] = []
+    for module in (models.text_encoder, models.vae_encoder, models.vae_decoder, models.unet):
+        for param in module.parameters():
+            if param.requires_grad:
+                params.append(param)
+    return params
+
+
+def _encode_text(
+    tokenizer: CLIPTokenizer, prompts: List[str], device: torch.device, text_encoder: nn.Module
+) -> torch.Tensor:
+    tokens = tokenizer(
+        prompts,
+        padding="max_length",
+        truncation=True,
+        max_length=77,
+        return_tensors="pt",
+    ).input_ids
+    tokens = tokens.to(device)
+    return text_encoder(tokens)
+
+
+def _encode_images(pixels: torch.Tensor, vae_encoder: nn.Module, generator: torch.Generator) -> torch.Tensor:
+    noise = torch.randn(
+        (pixels.shape[0], 4, pixels.shape[2] // 8, pixels.shape[3] // 8),
+        generator=generator,
+        device=pixels.device,
+    )
+    return vae_encoder(pixels, noise)
+
+
+def train_text_to_image(config: TrainConfig) -> None:
+    device = torch.device(config.device)
+    dataset = ImageTextDataset(config.metadata_path, config.images_root, config.resolution)
+    dataloader = DataLoader(
+        dataset,
+        batch_size=config.batch_size,
+        shuffle=True,
+        num_workers=config.num_workers,
+        pin_memory=device.type == "cuda",
+        drop_last=True,
+    )
+    tokenizer = CLIPTokenizer.from_pretrained(config.tokenizer_path)
+    models = _prepare_models(config)
+    models.to(device)
+
+    params = _gather_trainable_parameters(models)
+    optimizer = AdamW(params, lr=config.learning_rate, weight_decay=config.weight_decay)
+
+    scaler = torch.cuda.amp.GradScaler(enabled=config.mixed_precision and device.type == "cuda")
+    generator = torch.Generator(device=device)
+    sampler = DDPMSampler(generator)
+
+    global_step = 0
+    total_steps = min(config.max_train_steps, config.num_epochs * math.ceil(len(dataset) / config.batch_size))
+    output_dir = Path(config.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    progress_bar = tqdm(total=total_steps, desc="training")
+
+    for epoch in range(config.num_epochs):
+        for batch in dataloader:
+            pixel_values = batch["pixel_values"].to(device)
+            prompts: List[str] = batch["text"]  # type: ignore[assignment]
+
+            with torch.no_grad():
+                text_embeddings = _encode_text(tokenizer, prompts, device, models.text_encoder)
+                latents = _encode_images(pixel_values, models.vae_encoder, generator)
+                noise = torch.randn_like(latents, generator=generator)
+                timesteps = torch.randint(
+                    0,
+                    sampler.num_train_timesteps,
+                    (latents.shape[0],),
+                    device=device,
+                    generator=generator,
+                ).long()
+                noisy_latents = sampler.add_noise(latents, timesteps)
+
+            time_embeddings = get_time_embedding(timesteps).to(device)
+
+            with torch.cuda.amp.autocast(enabled=config.mixed_precision and device.type == "cuda"):
+                noise_pred = models.unet(noisy_latents, text_embeddings, time_embeddings)
+                loss = F.mse_loss(noise_pred, noise)
+
+            scaler.scale(loss / config.gradient_accumulation).backward()
+
+            if (global_step + 1) % config.gradient_accumulation == 0:
+                scaler.step(optimizer)
+                scaler.update()
+                optimizer.zero_grad(set_to_none=True)
+
+            global_step += 1
+            progress_bar.update(1)
+            progress_bar.set_postfix({"loss": f"{loss.item():.4f}"})
+
+            if global_step % config.save_every == 0:
+                _save_checkpoint(models, optimizer, global_step, output_dir)
+
+            if global_step >= config.max_train_steps:
+                break
+
+        if global_step >= config.max_train_steps:
+            break
+
+    progress_bar.close()
+    _save_checkpoint(models, optimizer, global_step, output_dir)
+
+
+def _save_checkpoint(models: StableDiffusionModels, optimizer: AdamW, step: int, output_dir: Path) -> None:
+    checkpoint = {
+        "text_encoder": models.text_encoder.state_dict(),
+        "vae_encoder": models.vae_encoder.state_dict(),
+        "vae_decoder": models.vae_decoder.state_dict(),
+        "unet": models.unet.state_dict(),
+        "optimizer": optimizer.state_dict(),
+        "step": step,
+    }
+    torch.save(checkpoint, output_dir / f"checkpoint-{step:06d}.pt")
+
+
+__all__ = ["ImageTextDataset", "TrainConfig", "train_text_to_image"]

--- a/train_new.py
+++ b/train_new.py
@@ -1,0 +1,38 @@
+"""Train Stable Diffusion from scratch on a compact demonstration dataset."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from train_model import TrainConfig, train_text_to_image
+
+DATA_ROOT = Path("data/toy_dataset")
+METADATA_PATH = DATA_ROOT / "captions.csv"
+IMAGES_ROOT = DATA_ROOT / "images"
+TOKENIZER_NAME = "openai/clip-vit-large-patch14"
+OUTPUT_DIR = Path("experiments/toy_run")
+
+
+def main() -> None:
+    config = TrainConfig(
+        output_dir=str(OUTPUT_DIR),
+        tokenizer_path=TOKENIZER_NAME,
+        metadata_path=str(METADATA_PATH),
+        images_root=str(IMAGES_ROOT),
+        pretrained_ckpt=None,
+        batch_size=2,
+        gradient_accumulation=4,
+        learning_rate=5e-5,
+        weight_decay=0.0,
+        num_epochs=20,
+        max_train_steps=5_000,
+        save_every=500,
+        train_text_encoder=True,
+        train_vae=True,
+        mixed_precision=False,
+        resolution=256,
+    )
+    train_text_to_image(config)
+
+
+if __name__ == "__main__":
+    main()

--- a/train_pretrain.py
+++ b/train_pretrain.py
@@ -1,0 +1,38 @@
+"""Fine-tune Stable Diffusion on a large professional dataset."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from train_model import TrainConfig, train_text_to_image
+
+DATA_ROOT = Path("/datasets/laion-aesthetic-v2")
+METADATA_PATH = DATA_ROOT / "metadata/laion-aesthetic-6.5plus.csv"
+IMAGES_ROOT = DATA_ROOT / "images"
+PRETRAINED_WEIGHTS = Path("/path/to/v1-5-pruned-emaonly.ckpt")
+TOKENIZER_NAME = "openai/clip-vit-large-patch14"
+OUTPUT_DIR = Path("experiments/laion_finetune")
+
+
+def main() -> None:
+    config = TrainConfig(
+        output_dir=str(OUTPUT_DIR),
+        tokenizer_path=TOKENIZER_NAME,
+        metadata_path=str(METADATA_PATH),
+        images_root=str(IMAGES_ROOT),
+        pretrained_ckpt=str(PRETRAINED_WEIGHTS),
+        batch_size=6,
+        gradient_accumulation=2,
+        learning_rate=1e-5,
+        weight_decay=0.01,
+        num_epochs=4,
+        max_train_steps=40_000,
+        save_every=2_000,
+        train_text_encoder=True,
+        train_vae=False,
+        mixed_precision=True,
+    )
+    train_text_to_image(config)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `model_define.py` with a beginner-friendly API to instantiate Stable Diffusion components
- centralize reusable data loading and training utilities in `train_model.py`
- create runnable scripts for image generation, large-scale finetuning, and scratch training

## Testing
- python -m compileall gen_image.py train_model.py train_new.py train_pretrain.py model_define.py

------
https://chatgpt.com/codex/tasks/task_b_68d26c6267e4832e99d2c7a34bfb237b