### PR TITLE
Update training scripts to use laion dataset

### DIFF
--- a/sd/train_new.py
+++ b/sd/train_new.py
@@ -5,8 +5,9 @@ from pathlib import Path
 
 from train_model import TrainConfig, train_text_to_image
 
-DATA_ROOT = Path("data/toy_dataset")
-METADATA_PATH = DATA_ROOT / "captions.csv"
+REPO_ROOT = Path(__file__).resolve().parent
+DATA_ROOT = REPO_ROOT / "laion_aesthetic6"
+METADATA_PATH = DATA_ROOT / "metadata.jsonl"
 IMAGES_ROOT = DATA_ROOT / "images"
 TOKENIZER_NAME = "openai/clip-vit-large-patch14"
 OUTPUT_DIR = Path("experiments/toy_run")

--- a/sd/train_pretrain.py
+++ b/sd/train_pretrain.py
@@ -5,8 +5,9 @@ from pathlib import Path
 
 from train_model import TrainConfig, train_text_to_image
 
-DATA_ROOT = Path("/datasets/laion_aesthetic6")
-METADATA_PATH = DATA_ROOT / "metadata/laion-aesthetic-6.5plus.csv"
+REPO_ROOT = Path(__file__).resolve().parent
+DATA_ROOT = REPO_ROOT / "laion_aesthetic6"
+METADATA_PATH = DATA_ROOT / "metadata.jsonl"
 IMAGES_ROOT = DATA_ROOT / "images"
 PRETRAINED_WEIGHTS = Path("../data/v1-5-pruned-emaonly.ckpt")
 TOKENIZER_NAME = "openai/clip-vit-large-patch14"


### PR DESCRIPTION
## Summary
- update the fine-tuning and from-scratch training entrypoints to point at the bundled laion_aesthetic6 dataset
- extend the shared ImageTextDataset helper so it can load JSONL metadata exported by the downloader

## Testing
- python -m compileall sd/train_pretrain.py sd/train_new.py sd/train_model.py

------
https://chatgpt.com/codex/tasks/task_b_68d39a82ed28832ebf255cf2a39ccd40